### PR TITLE
Fix a memory leak in the NEXRAD display resource

### DIFF
--- a/cave/com.raytheon.viz.radar/src/com/raytheon/viz/radar/rsc/map/RadarMapMouseHandler.java
+++ b/cave/com.raytheon.viz.radar/src/com/raytheon/viz/radar/rsc/map/RadarMapMouseHandler.java
@@ -97,7 +97,10 @@ public class RadarMapMouseHandler extends InputAdapter {
             RadarStation pt = getPtWithinMinDist(pts, loc);
             
             Shell shell = ((Control) e.widget).getShell();
-            Cursor cursor = null;
+            Cursor cursor = shell.getCursor();
+            if(cursor != null) {
+                cursor.dispose();
+            }
             
             if (pt != null) {
             	cursor = new Cursor(Display.getCurrent(), SWT.CURSOR_HAND);


### PR DESCRIPTION
- make sure to properly dispose of an existing cursor before defining and setting a new one